### PR TITLE
feat(api-cache): 实现高频接口缓存预热功能

### DIFF
--- a/cubic-backend/src/main/java/com/saki/apiproject/cache/Impl/InterfaceCacheServiceImpl.java
+++ b/cubic-backend/src/main/java/com/saki/apiproject/cache/Impl/InterfaceCacheServiceImpl.java
@@ -1,0 +1,79 @@
+package com.saki.apiproject.cache.Impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.saki.apiproject.cache.InterfaceCacheService;
+import com.saki.apiproject.constant.CacheExpireConstant;
+import com.saki.apiproject.constant.RedisKeyConstant;
+import com.saki.apiproject.mapper.InterfaceInfoMapper;
+import com.saki.common.model.entity.InterfaceInfo;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 接口缓存实现类
+ * @author sakisaki
+ * @date 2025/9/17 22:18
+ */
+@Service
+public class InterfaceCacheServiceImpl implements InterfaceCacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private final InterfaceInfoMapper interfaceInfoMapper;
+
+    public InterfaceCacheServiceImpl(RedisTemplate<String, Object> redisTemplate, InterfaceInfoMapper interfaceInfoMapper) {
+        this.redisTemplate = redisTemplate;
+        this.interfaceInfoMapper = interfaceInfoMapper;
+    }
+
+    /**
+     * 缓存预热 - 启动时执行
+     */
+    @Override
+    public void preheatHotInterfaces() {
+        // 查询调用次数最多的前三个接口
+        List<InterfaceInfo> hotList = interfaceInfoMapper.selectList(new QueryWrapper<InterfaceInfo>().orderByDesc("totalInvokes").last("limit 3"));
+
+        if (hotList != null && !hotList.isEmpty()) {
+            // 缓存热点列表
+            redisTemplate.opsForValue().set(RedisKeyConstant.INTERFACE_HOT_LIST, hotList, CacheExpireConstant.INTERFACE_HOT_LIST_EXPIRE, TimeUnit.MINUTES);
+
+            // 缓存每个接口详情
+            for (InterfaceInfo info : hotList) {
+                redisTemplate.opsForValue().set(RedisKeyConstant.INTERFACE_INFO_PREFIX + info.getId(), info, CacheExpireConstant.INTERFACE_INFO_EXPIRE, TimeUnit.MINUTES);
+            }
+        }
+    }
+
+    /**
+     * 获取接口详情（优先缓存）
+     */
+    @Override
+    public InterfaceInfo getInterfaceInfoById(Long id) {
+        String key = RedisKeyConstant.INTERFACE_INFO_PREFIX + id;
+        InterfaceInfo info = (InterfaceInfo) redisTemplate.opsForValue().get(key);
+        if (info != null) {
+            return info;
+        }
+        // 缓存没有，查数据库并写入缓存
+        info = interfaceInfoMapper.selectById(id);
+        if (info != null) {
+            redisTemplate.opsForValue().set(key, info, CacheExpireConstant.INTERFACE_INFO_EXPIRE, TimeUnit.MINUTES);
+        }
+        return info;
+    }
+
+    /**
+     * 主动刷新缓存
+     */
+    @Override
+    public void refreshInterfaceCache(Long id) {
+        InterfaceInfo info = interfaceInfoMapper.selectById(id);
+        if (info != null) {
+            redisTemplate.opsForValue().set(RedisKeyConstant.INTERFACE_INFO_PREFIX + id, info, CacheExpireConstant.INTERFACE_INFO_EXPIRE, TimeUnit.MINUTES);
+        }
+    }
+}

--- a/cubic-backend/src/main/java/com/saki/apiproject/cache/InterfaceCacheService.java
+++ b/cubic-backend/src/main/java/com/saki/apiproject/cache/InterfaceCacheService.java
@@ -1,0 +1,26 @@
+package com.saki.apiproject.cache;
+
+
+import com.saki.common.model.entity.InterfaceInfo;
+
+/**
+ * 接口信息缓存 接口
+ * @author sakisaki
+ * @date 2025/9/17 21:52
+ */
+public interface InterfaceCacheService {
+    /**
+     * 缓存预热
+     */
+    void preheatHotInterfaces();
+
+    /**
+     * 获取接口详情（带缓存）
+     */
+    InterfaceInfo getInterfaceInfoById(Long id);
+
+    /**
+     * 刷新某个接口缓存
+     */
+    void refreshInterfaceCache(Long id);
+}

--- a/cubic-backend/src/main/java/com/saki/apiproject/constant/CacheExpireConstant.java
+++ b/cubic-backend/src/main/java/com/saki/apiproject/constant/CacheExpireConstant.java
@@ -1,0 +1,19 @@
+package com.saki.apiproject.constant;
+
+/**
+ * 缓存过期时间常量
+ * @author sakisaki
+ * @date 2025/9/17 22:22
+ */
+public interface CacheExpireConstant {
+
+    /**
+     * 热点接口列表缓存过期时间（30分钟）
+     */
+    long INTERFACE_HOT_LIST_EXPIRE = 30L;
+
+    /**
+     * 热点接口缓存过期时间（60 分钟）
+     */
+    long INTERFACE_INFO_EXPIRE = 10L;
+}

--- a/cubic-backend/src/main/java/com/saki/apiproject/constant/RedisKeyConstant.java
+++ b/cubic-backend/src/main/java/com/saki/apiproject/constant/RedisKeyConstant.java
@@ -1,0 +1,19 @@
+package com.saki.apiproject.constant;
+
+/**
+ * Redis Key 常量
+ * @author sakisaki
+ * @date 2025/9/17 22:02
+ */
+public interface RedisKeyConstant {
+
+    /**
+     * 热点接口列表
+     */
+    String INTERFACE_HOT_LIST = "interface:hot:list";
+
+    /**
+     * 单个接口详情 key 前缀，使用时拼接 id
+     */
+    String INTERFACE_INFO_PREFIX = "interface:info:";
+}

--- a/cubic-backend/src/main/java/com/saki/apiproject/init/CachePreheatRunner.java
+++ b/cubic-backend/src/main/java/com/saki/apiproject/init/CachePreheatRunner.java
@@ -1,0 +1,24 @@
+package com.saki.apiproject.init;
+
+import com.saki.apiproject.cache.InterfaceCacheService;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+
+/**
+ * 项目启动时预热缓存
+ * @author sakisaki
+ * @date 2025/9/17 23:20
+ */
+@Component
+public class CachePreheatRunner implements CommandLineRunner {
+
+    @Resource
+    private InterfaceCacheService interfaceCacheService;
+
+    @Override
+    public void run(String... args) {
+        interfaceCacheService.preheatHotInterfaces();
+    }
+}


### PR DESCRIPTION
- ✅ 先把 InterfaceCacheService 的预热 + 查询缓存 + 刷新缓存做完。 
- ✅ 在 CachePreheatRunner 中调用预热逻辑。 
- ✅ 在 Controller/Service 中改造获取接口详情的地方，走缓存逻辑。