### PR TITLE
refactor：删除冗余代码，并重构API客户端配置

### DIFF
--- a/cubic-client-sdk/src/main/java/com/saki/cubicapiclientsdk/client/CubicApiClient.java
+++ b/cubic-client-sdk/src/main/java/com/saki/cubicapiclientsdk/client/CubicApiClient.java
@@ -25,45 +25,8 @@ public class CubicApiClient {
      */
     private String secretKey;
 
-    // public String getNameByGet(String name) {
-    //     // 可以单独传入http参数，这样参数会自动做URL编码，拼接在URL中
-    //     HashMap<String, Object> paramMap = new HashMap<>();
-    //     paramMap.put("name", name);
-    //     String result = HttpUtil.get(GATEWAY_HOST + "/api/name/", paramMap);
-    //     System.out.println(result);
-    //     return result;
-    // }
-    //
-    // public String getNameByPost(String name) {
-    //     // 可以单独传入http参数，这样参数会自动做URL编码，拼接在URL中
-    //     HashMap<String, Object> paramMap = new HashMap<>();
-    //     paramMap.put("name", name);
-    //     String result = HttpUtil.post(GATEWAY_HOST + "/api/name/", paramMap);
-    //     System.out.println(result);
-    //     return result;
-    // }
-    //
-    // private Map<String, String> getHeaderMap(String body) {
-    //     Map<String, String> hashMap = new HashMap<>();
-    //     hashMap.put("accessKey", accessKey);
-    //     // 一定不能直接发送
-    //     // hashMap.put("secretKey", secretKey);
-    //     hashMap.put("nonce", RandomUtil.randomNumbers(4));
-    //     hashMap.put("body", body);
-    //     hashMap.put("timestamp", String.valueOf(System.currentTimeMillis() / 1000));
-    //     hashMap.put("sign", getSign(body, secretKey));
-    //     return hashMap;
-    // }
-    //
-    // public String getUsernameByPost(User user) {
-    //     String json = JSONUtil.toJsonStr(user);
-    //     HttpResponse httpResponse = HttpRequest.post(GATEWAY_HOST + "/api/name/user")
-    //             .addHeaders(getHeaderMap(json))
-    //             .body(json)
-    //             .execute();
-    //     System.out.println(httpResponse.getStatus());
-    //     String result = httpResponse.body();
-    //     System.out.println(result);
-    //     return result;
-    // }
+    /**
+     * 网关
+     */
+    private String gatewayHost;
 }

--- a/cubic-client-sdk/src/main/java/com/saki/cubicapiclientsdk/config/CubicApiClientConfig.java
+++ b/cubic-client-sdk/src/main/java/com/saki/cubicapiclientsdk/config/CubicApiClientConfig.java
@@ -1,52 +1,29 @@
 package com.saki.cubicapiclientsdk.config;
 
-import com.saki.cubicapiclientsdk.client.CubicApiClient;
+import com.saki.cubicapiclientsdk.factory.CubicApiClientFactory;
 import com.saki.cubicapiclientsdk.service.ApiService;
 import com.saki.cubicapiclientsdk.service.impl.ApiServiceImpl;
-import lombok.Data;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 /**
  * @author sakisaki
  * @version 1.0.0
- * @description JsApi 客户端配置
+ * @description 向Spring容器注入 CubicApiClientFactory 和 ApiService 这两个Bean，其它可以通过自动注入直接使用
  * @date 2024-09-13 03:28:17
  */
-@Data
 @Configuration
-@ComponentScan
-@ConfigurationProperties("cubic.api.client")
+@EnableConfigurationProperties(CubicApiClientProperties.class)
 public class CubicApiClientConfig {
 
-    /**
-     * 访问密钥
-     */
-    private String accessKey;
-    /**
-     * 秘密密钥
-     */
-    private String secretKey;
-    /**
-     * 网关
-     */
-    private String host;
-
     @Bean
-    public CubicApiClient cubicApiClient() {
-        return new CubicApiClient(accessKey, secretKey);
+    public CubicApiClientFactory cubicApiClientFactory(CubicApiClientProperties properties) {
+        return new CubicApiClientFactory(properties);
     }
 
     @Bean
     public ApiService apiService() {
-        ApiServiceImpl apiServiceImpl = new ApiServiceImpl();
-        apiServiceImpl.setCubicApiClient(new CubicApiClient(accessKey, secretKey));
-        if (StringUtils.isNotBlank(host)) {
-            apiServiceImpl.setGatewayHost(host);
-        }
-        return apiServiceImpl;
+        return new ApiServiceImpl();
     }
 }

--- a/cubic-client-sdk/src/main/java/com/saki/cubicapiclientsdk/config/CubicApiClientProperties.java
+++ b/cubic-client-sdk/src/main/java/com/saki/cubicapiclientsdk/config/CubicApiClientProperties.java
@@ -1,0 +1,15 @@
+package com.saki.cubicapiclientsdk.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 通过外部化配置机制 + 自动装配 读取配置文件里的网关地址
+ * @author sakisaki
+ * @date 2025/9/20 10:37
+ */
+@Data
+@ConfigurationProperties(prefix = "cubic")
+public class CubicApiClientProperties {
+    private String gatewayHost;
+}

--- a/cubic-client-sdk/src/main/java/com/saki/cubicapiclientsdk/factory/CubicApiClientFactory.java
+++ b/cubic-client-sdk/src/main/java/com/saki/cubicapiclientsdk/factory/CubicApiClientFactory.java
@@ -1,0 +1,24 @@
+package com.saki.cubicapiclientsdk.factory;
+
+import com.saki.cubicapiclientsdk.client.CubicApiClient;
+import com.saki.cubicapiclientsdk.config.CubicApiClientProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * API 客户端工厂，通过工厂模式在每次请求时生成新的 client，同时避免直接操作 Bean
+ * @author sakisaki
+ * @date 2025/9/20 12:34
+ */
+@Component
+public class CubicApiClientFactory {
+
+    private final CubicApiClientProperties properties;
+
+    public CubicApiClientFactory(CubicApiClientProperties properties) {
+        this.properties = properties;
+    }
+
+    public CubicApiClient newCubicClient(String accessKey, String secretKey) {
+        return new CubicApiClient(accessKey, secretKey, properties.getGatewayHost());
+    }
+}


### PR DESCRIPTION
- 新建 CubicApiClient类 工厂用于每次请求时生成新的 client，同时避免直接操作 Bean；
- 新建 CubicApiClientProperties配置类 用于通过外部化配置机制 + 自动装配 读取配置文件里的网关地址
- 改造 CubicApiClientConfig 配置类，向Spring容器注入 CubicApiClientFactory 和 ApiService 这两个Bean，其它可以通过自动注入直接使用