### PR TITLE
refactor: 修改创建CubicClient的逻辑

### DIFF
--- a/cubic-backend/src/main/java/com/saki/apiproject/controller/InterfaceInfoController.java
+++ b/cubic-backend/src/main/java/com/saki/apiproject/controller/InterfaceInfoController.java
@@ -30,6 +30,7 @@ import com.saki.common.model.dto.ResponseParamsField;
 import com.saki.common.model.entity.InterfaceInfo;
 import com.saki.common.model.entity.User;
 import com.saki.cubicapiclientsdk.client.CubicApiClient;
+import com.saki.cubicapiclientsdk.factory.CubicApiClientFactory;
 import com.saki.cubicapiclientsdk.model.request.CurrentRequest;
 import com.saki.cubicapiclientsdk.model.response.ResultResponse;
 import com.saki.cubicapiclientsdk.service.ApiService;
@@ -61,6 +62,9 @@ public class InterfaceInfoController {
 
     @Resource
     private InterfaceCacheService interfaceCacheService;
+
+    @Resource
+    private CubicApiClientFactory cubicApiClientFactory;
 
     @Resource
     private UserService userService;
@@ -343,11 +347,10 @@ public class InterfaceInfoController {
         }
         Map<String, Object> params = new Gson().fromJson(requestParams, new TypeToken<Map<String, Object>>() {
         }.getType());
+        
         User loginUser = userService.getLoginUser(request);
-        String accessKey = loginUser.getAccessKey();
-        String secretKey = loginUser.getSecretKey();
         try {
-            CubicApiClient cubicApiClient = new CubicApiClient(accessKey, secretKey);
+            CubicApiClient cubicApiClient = cubicApiClientFactory.newCubicClient(loginUser.getAccessKey(), loginUser.getSecretKey());
             CurrentRequest currentRequest = new CurrentRequest();
             currentRequest.setMethod(interfaceInfo.getMethod());
             currentRequest.setPath(interfaceInfo.getUrl());

--- a/cubic-backend/src/main/resources/application-prod.yml
+++ b/cubic-backend/src/main/resources/application-prod.yml
@@ -66,6 +66,8 @@ mybatis-plus:
       logic-delete-field: isDelete # 全局逻辑删除的实体字段名(since 3.3.0,配置后可以忽略不配置步骤2)
       logic-delete-value: 1 # 逻辑已删除值(默认为 1)
       logic-not-delete-value: 0 # 逻辑未删除值(默认为 0)
+cubic:
+  gatewayHost: https://api-gateway.website-of-js.cn
 dubbo:
   application:
     name: dubbo-springboot-demo-provider

--- a/cubic-backend/src/main/resources/application.yml
+++ b/cubic-backend/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   application:
     name: cubic-backend
-#   DataSource Config
+  #   DataSource Config
   datasource:
     url: jdbc:mysql://localhost:3306/jsapi?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Shanghai
     username: root
@@ -64,11 +64,8 @@ mybatis-plus:
       logic-delete-field: isDelete # 全局逻辑删除的实体字段名(since 3.3.0,配置后可以忽略不配置步骤2)
       logic-delete-value: 1 # 逻辑已删除值(默认为 1)
       logic-not-delete-value: 0 # 逻辑未删除值(默认为 0)
-# 仅供测试，实际应该根据登录用户获取对应的 ak、sk
-#yuapi:
-#  client:
-#    access-key: js
-#    secret-key: abcdefgh
+cubic:
+  gatewayHost: http://localhost:8090
 dubbo:
   application:
     name: dubbo-springboot-demo-provider


### PR DESCRIPTION
- 通过 cubicApiClientFactory 创建 client，确保线程安全；
- 在 yml 文件中添加gatewayHost字段，在系统启动时供配置Bean读取，不用手动传入gatewayHost，只需传入ak/sk，